### PR TITLE
fix: query para paginar a tabela de usuários na área do prestador

### DIFF
--- a/src/main/java/com/soulcode/goserviceapp/domain/Usuario.java
+++ b/src/main/java/com/soulcode/goserviceapp/domain/Usuario.java
@@ -2,9 +2,7 @@ package com.soulcode.goserviceapp.domain;
 
 import com.soulcode.goserviceapp.domain.enums.Perfil;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/com/soulcode/goserviceapp/repository/UsuarioRepository.java
+++ b/src/main/java/com/soulcode/goserviceapp/repository/UsuarioRepository.java
@@ -27,8 +27,8 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
     @Query(value = "SELECT u.perfil AS perfil, COUNT(*) AS quantidade FROM usuarios AS u GROUP BY u.perfil", nativeQuery = true)
     List<Usuario> findbyPerfil();
 
-    @Query(value = "SELECT * FROM usuarios ORDER BY id LIMIT 10 OFFSET ((@pageNumber - 1) * 10)", nativeQuery = true)
-    List<Usuario> findLimited();
+    @Query(value = "SELECT * FROM usuarios ORDER BY id LIMIT 10 OFFSET ?", nativeQuery = true)
+    List<Usuario> findLimited(int offset);
 
     @Query(value = "SELECT * FROM usuarios WHERE UPPER(nome) LIKE UPPER(CONCAT('%', :nome, '%'))", nativeQuery = true)
     List<Usuario> findByName(@Param("nome") String nome);

--- a/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
+++ b/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
@@ -26,7 +26,20 @@ public class UsuarioService {
     @Autowired
     private UsuarioRepository usuarioRepository;
 
-    @Cacheable(cacheNames = "redisCache")
+    public Long paginasRegistros(){
+        Long totalRecords = usuarioRepository.count();
+        Long totalPages = totalRecords / 10;
+        if (totalRecords % 10 != 0){
+            totalPages++;
+        }
+        return totalPages;
+    }
+
+    public List<Usuario> findLimited(int offset){
+        return usuarioRepository.findLimited(offset);
+    }
+
+//    @Cacheable(cacheNames = "redisCache2")
     public List<Usuario> findAll(){
         System.err.println("BUSCANDO USUARIOS NO BANCO DE DADOS...");
         return usuarioRepository.findAll();
@@ -38,7 +51,6 @@ public class UsuarioService {
         }
         throw new UsuarioNaoEncontradoException();
     }
-
 
     public Usuario findById(Long id) {
         Optional<Usuario> result = usuarioRepository.findById(id);


### PR DESCRIPTION
- Correção da query no UsuarioRepository que retornava a consulta de forma páginada: 
![image](https://github.com/luc4sleite/goservice/assets/115735167/0a053288-6c5a-4d27-8179-c3bc276da16a)

- Criação do método e UsuarioService para realizar essa consulta: 
![image](https://github.com/luc4sleite/goservice/assets/115735167/a4ece58d-5615-4f8a-8100-8109eb805add)

- Criação do método para calcular a quantidade de paginas que teriam por registros: 
![image](https://github.com/luc4sleite/goservice/assets/115735167/62e567ef-409a-4b12-8b77-ce5537c2fa77)
